### PR TITLE
Remove breakpoint-sass from bower dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,8 +22,5 @@
     "presentation",
     "material",
     "theme"
-  ],
-  "dependencies": {
-    "breakpoint-sass": "~2.6.1"
-  }
+  ]
 }


### PR DESCRIPTION
When bower uses to install this theme, it remove all sass files. I this case I think that "breakpoint-sass" is absolutely unnecessary.
