### PR TITLE
Add slide visibility in fullscreen

### DIFF
--- a/styles/slide/slide-full.css
+++ b/styles/slide/slide-full.css
@@ -5,10 +5,12 @@
     top: 0;
     left: 0;
     clip: rect(0 0 0 0);
+    visibility: hidden;
 }
 
 /* Active */
 
 .shower.full .slide.active {
     clip: auto;
+    visibility: visible;
 }


### PR DESCRIPTION
## Slide visibility

When `visibility` property is not set, in fullscreen mode it's possible to focus on links from other slides (see screenshot). By setting `visibility: hidden` for hidden slides interactive elements [don't get focus](https://developer.mozilla.org/en-US/docs/Web/CSS/visibility#Values) any longer.

![tabindex](https://user-images.githubusercontent.com/10166916/44606027-de16f600-a7eb-11e8-956c-77f9f1786104.gif)