### PR TITLE
fix horizontal scroll on windows

### DIFF
--- a/styles/shower/shower-list.css
+++ b/styles/shower/shower-list.css
@@ -30,6 +30,7 @@
         calc(var(--slide-width) * var(--slide-scale))
     );
     background-color: var(--color-back);
+    overflow-x: hidden;
 }
 
 /* IE & Edge Fix */

--- a/styles/shower/shower-list.css
+++ b/styles/shower/shower-list.css
@@ -15,6 +15,7 @@
         var(--shower-list-block)
         var(--shower-list-inline);
 
+    overflow-x: hidden;
     box-sizing: border-box;
     width: 100%;
     display: grid;
@@ -30,7 +31,6 @@
         calc(var(--slide-width) * var(--slide-scale))
     );
     background-color: var(--color-back);
-    overflow-x: hidden;
 }
 
 /* IE & Edge Fix */


### PR DESCRIPTION
When used on Windows this theme always have a horizontal scroll, because the `header` has the property `width: 100vw;`. The scrollbars on Windows have width or height (depends on position) and located inside the viewport, so they always "affect" when use `vh` or `vw`.

![image](https://user-images.githubusercontent.com/34187607/126327063-2ce723a1-770f-46ec-8474-71f374ab32ef.png)
